### PR TITLE
fix: prevent bufio panics and goroutine leaks in SSH client

### DIFF
--- a/http/router.go
+++ b/http/router.go
@@ -26,6 +26,20 @@ var (
 	mu sync.Mutex
 )
 
+// recoveryMiddleware catches panics in HTTP handlers and returns a 500 error
+// instead of crashing the process.
+func recoveryMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer func() {
+			if err := recover(); err != nil {
+				log.Printf("[HTTP] Recovered from panic on %s: %v\n", r.URL.Path, err)
+				http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			}
+		}()
+		next.ServeHTTP(w, r)
+	})
+}
+
 // NewRouter sets up all HTTP routes and returns the router.
 func NewRouter(cfg config.Config) http.Handler {
 	// parse refresh interval
@@ -144,5 +158,5 @@ func NewRouter(cfg config.Config) http.Handler {
 		w.Write([]byte("TS6Viewer is running!"))
 	})
 
-	return mux
+	return recoveryMiddleware(mux)
 }

--- a/internal/ts6/ssh.go
+++ b/internal/ts6/ssh.go
@@ -18,6 +18,11 @@ import (
 	"golang.org/x/crypto/ssh"
 )
 
+// sshReadBufferSize is the size of the bufio.Reader buffer used for reading
+// ServerQuery responses. The default 4096 is too small for responses like
+// channellist or clientlist on servers with many channels/clients.
+const sshReadBufferSize = 65536
+
 // SSHClient represents a persistent SSH ServerQuery connection.
 type SSHClient struct {
 	cfg      *config.Config
@@ -28,7 +33,9 @@ type SSHClient struct {
 	stdin   io.WriteCloser
 	reader  *bufio.Reader
 
-	mu sync.Mutex // protects command execution and reconnect
+	mu   sync.Mutex // protects command execution and reconnect
+	done chan struct{}
+	once sync.Once
 }
 
 var (
@@ -193,7 +200,8 @@ func newSSHClientBase(cfg *config.Config) (*SSHClient, error) {
 		ssh:     client,
 		session: session,
 		stdin:   stdin,
-		reader:  bufio.NewReader(stdout),
+		reader:  bufio.NewReaderSize(stdout, sshReadBufferSize),
+		done:    make(chan struct{}),
 	}
 
 	log.Println("[SSH] Waiting for welcome message")
@@ -238,19 +246,27 @@ func newSSHClientBase(cfg *config.Config) (*SSHClient, error) {
 }
 
 // keepAlive sends periodic version commands to prevent idle timeout.
+// It stops when the client is closed via the done channel.
 func (c *SSHClient) keepAlive() {
 	ticker := time.NewTicker(30 * time.Second)
 	defer ticker.Stop()
 
-	for range ticker.C {
-		if c.IsClosed() {
+	for {
+		select {
+		case <-c.done:
+			log.Println("[SSH] keepAlive stopped (connection closed)")
 			return
-		}
-		log.Println("[SSH] Sending keepalive ping")
-		_, err := c.Exec("version")
-		if err != nil {
-			log.Printf("[SSH] Keepalive failed: %v. Attempting reconnect\n", err)
-			_ = c.reconnect()
+		case <-ticker.C:
+			if c.IsClosed() {
+				return
+			}
+			log.Println("[SSH] Sending keepalive ping")
+			_, err := c.Exec("version")
+			if err != nil {
+				log.Printf("[SSH] Keepalive failed: %v. Attempting reconnect\n", err)
+				_ = c.reconnect()
+				return // stop this goroutine; reconnect spawns a new one
+			}
 		}
 	}
 }
@@ -265,8 +281,18 @@ func (c *SSHClient) Exec(cmd string) (string, error) {
 }
 
 // exec sends a raw command and reads the response.
-func (c *SSHClient) exec(cmd string) (string, error) {
-	_, err := c.stdin.Write([]byte(cmd + "\n"))
+// It includes panic recovery to handle unexpected bufio errors gracefully
+// instead of crashing the process.
+func (c *SSHClient) exec(cmd string) (result string, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Printf("[SSH] Recovered from panic during exec(%q): %v\n", cmd, r)
+			err = fmt.Errorf("panic during command execution: %v", r)
+			result = ""
+		}
+	}()
+
+	_, err = c.stdin.Write([]byte(cmd + "\n"))
 	if err != nil {
 		return "", err
 	}
@@ -275,9 +301,9 @@ func (c *SSHClient) exec(cmd string) (string, error) {
 	var last string
 
 	for {
-		line, err := c.reader.ReadString('\n')
-		if err != nil {
-			return "", err
+		line, readErr := c.reader.ReadString('\n')
+		if readErr != nil {
+			return "", readErr
 		}
 		line = strings.TrimSpace(line)
 		lines = append(lines, line)
@@ -398,7 +424,8 @@ func isConnectionError(err error) bool {
 	return strings.Contains(msg, "eof") ||
 		strings.Contains(msg, "broken pipe") ||
 		strings.Contains(msg, "connection reset") ||
-		strings.Contains(msg, "use of closed network connection")
+		strings.Contains(msg, "use of closed network connection") ||
+		strings.Contains(msg, "panic during command execution")
 }
 
 // IsClosed checks whether the client is closed.
@@ -406,9 +433,13 @@ func (c *SSHClient) IsClosed() bool {
 	return c == nil || c.ssh == nil
 }
 
-// Close terminates the SSH session.
+// Close terminates the SSH session and signals the keepAlive goroutine to stop.
 func (c *SSHClient) Close() {
 	log.Println("[SSH] Closing SSH connection")
+
+	c.once.Do(func() {
+		close(c.done)
+	})
 
 	if c.session != nil {
 		_ = c.session.Close()


### PR DESCRIPTION
## Problem

On servers with many channels or clients, ServerQuery responses (e.g. `channellist`, `clientlist`) can exceed the default `bufio.Reader` buffer size of 4096 bytes. This causes runtime panics in `bufio.ReadSlice`:

```
http: panic serving ...: runtime error: slice bounds out of range [:5970] with capacity 4096
```

After a panic, the shared SSH connection enters a corrupted state and the viewer stops fetching data entirely — only keepalive `version` commands continue running. A container restart is required to recover.

Additionally, each reconnect spawns a new `keepAlive` goroutine without stopping the previous one, leading to goroutine accumulation over time (observed 3+ concurrent keepalive loops).

## Changes

**`internal/ts6/ssh.go`**
- Increase the `bufio.Reader` buffer from 4096 to 64KB (`bufio.NewReaderSize`) to accommodate large ServerQuery responses
- Add a `done` channel to `SSHClient` that signals the `keepAlive` goroutine to stop on `Close()`
- Return from `keepAlive` after triggering a reconnect so only one goroutine runs at a time
- Add `defer recover()` in `exec()` to catch unexpected panics and return them as errors instead of crashing
- Classify recovered panics as connection errors so `execSafe()` triggers an automatic reconnect

**`http/router.go`**
- Wrap the mux with a recovery middleware that catches unhandled panics and returns HTTP 500 instead of killing the process

## Testing

Deployed and tested on a TS6 server with 36 channels and 32 Zipline-hosted channel banners:
- Build succeeds, viewer starts and connects normally
- Data is fetched and cached on first request ("Viewer data updated and cached")
- Only one keepalive cycle per 30s interval (previously 3+)
- Page loads in ~300ms