### PR TITLE
Fix zombie SSH connections, add configurable max_width

### DIFF
--- a/cmd/server/config.example.json
+++ b/cmd/server/config.example.json
@@ -11,6 +11,9 @@
   "refresh_interval": "${REFRESH_INTERVAL}",
   "_comment_refresh_interval": "How often the viewer should auto-refresh (in seconds).",
 
+  "max_width": "${MAX_WIDTH}",
+  "_comment_max_width": "Maximum width of the viewer content on wide screens (CSS value, e.g. '800px', '1200px', '100%'). Default: '800px'.",
+
   "host_connection_link": "${HOST_CONNECTION_LINK}",
   "_comment_host_connection_link": "The URL or IP address of your TeamSpeak 6 server. This is used for display purposes and should match the actual server address.",
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -16,6 +16,7 @@ export USER="${USER:-serveradmin}"
 export PASSWORD="${PASSWORD:-}"
 export ENABLE_VOICE_STATUS="${ENABLE_VOICE_STATUS:-true}"
 export SERVER_ID="${SERVER_ID:-1}"
+export MAX_WIDTH="${MAX_WIDTH:-800px}"
 
 echo "[entrypoint] starting TS6 Viewer"
 
@@ -47,6 +48,7 @@ echo "  USER=$USER"
 echo "  PASSWORD=*********"
 echo "  ENABLE_VOICE_STATUS=$ENABLE_VOICE_STATUS"
 echo "  SERVER_ID=$SERVER_ID"
+echo "  MAX_WIDTH=$MAX_WIDTH"
 
 echo "[entrypoint] Starting server..."
 

--- a/http/http-helper.go
+++ b/http/http-helper.go
@@ -68,11 +68,17 @@ func getViewerData(cfg *config.Config, force bool) (view.VMTS6Viewer, error) {
 		return view.VMTS6Viewer{}, err
 	}
 
+	maxWidth := cfg.MaxWidth
+	if maxWidth == "" {
+		maxWidth = "800px"
+	}
+
 	vmTS6Viewer := view.VMTS6Viewer{
 		VMServer:        view.BuildVMServer(cfg, info, clients),
 		VMChannels:      view.BuildVMChannels(channels, clients),
 		Theme:           cfg.Theme,
 		RefreshInterval: cfg.RefreshInterval,
+		MaxWidth:        maxWidth,
 	}
 
 	cacheData = vmTS6Viewer

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,6 +20,7 @@ type Config struct {
 
 	Theme           string `json:"theme"`
 	RefreshInterval string `json:"refresh_interval"`
+	MaxWidth        string `json:"max_width"`
 }
 
 func Load(path string) (*Config, error) {

--- a/internal/ts6/ssh.go
+++ b/internal/ts6/ssh.go
@@ -280,7 +280,7 @@ func (c *SSHClient) Exec(cmd string) (string, error) {
 	return c.execSafe(cmd)
 }
 
-// exec sends a raw command and reads the response.
+// exec sends a raw command and reads the response with a timeout.
 // It includes panic recovery to handle unexpected bufio errors gracefully
 // instead of crashing the process.
 func (c *SSHClient) exec(cmd string) (result string, err error) {
@@ -297,22 +297,38 @@ func (c *SSHClient) exec(cmd string) (result string, err error) {
 		return "", err
 	}
 
+	type readResult struct {
+		line string
+		err  error
+	}
+
 	var lines []string
 	var last string
 
 	for {
-		line, readErr := c.reader.ReadString('\n')
-		if readErr != nil {
-			return "", readErr
-		}
-		line = strings.TrimSpace(line)
-		lines = append(lines, line)
-		last = line
-		if strings.HasPrefix(line, "error id=") {
-			break
+		ch := make(chan readResult, 1)
+		go func() {
+			line, readErr := c.reader.ReadString('\n')
+			ch <- readResult{line, readErr}
+		}()
+
+		select {
+		case res := <-ch:
+			if res.err != nil {
+				return "", res.err
+			}
+			line := strings.TrimSpace(res.line)
+			lines = append(lines, line)
+			last = line
+			if strings.HasPrefix(line, "error id=") {
+				goto done
+			}
+		case <-time.After(15 * time.Second):
+			return "", fmt.Errorf("read timeout: no response within 15s")
 		}
 	}
 
+done:
 	raw := strings.Join(lines, "\n")
 
 	if strings.HasPrefix(last, "error id=") && last != "error id=0 msg=ok" {
@@ -425,7 +441,8 @@ func isConnectionError(err error) bool {
 		strings.Contains(msg, "broken pipe") ||
 		strings.Contains(msg, "connection reset") ||
 		strings.Contains(msg, "use of closed network connection") ||
-		strings.Contains(msg, "panic during command execution")
+		strings.Contains(msg, "panic during command execution") ||
+		strings.Contains(msg, "read timeout")
 }
 
 // IsClosed checks whether the client is closed.

--- a/internal/view/vm.go
+++ b/internal/view/vm.go
@@ -5,6 +5,7 @@ type VMTS6Viewer struct {
 	VMChannels      []*VMChannel
 	Theme           string
 	RefreshInterval string
+	MaxWidth        string
 }
 
 type VMServer struct {

--- a/internal/web/templates/ts6viewer.html
+++ b/internal/web/templates/ts6viewer.html
@@ -35,6 +35,11 @@
 <title>TS6 Viewer</title>
 
 <link rel="stylesheet" href="/static/{{.Theme}}.css">
+<style>
+@media (min-width: 600px) {
+    #channels, .server-info { max-width: {{.MaxWidth}} !important; }
+}
+</style>
 <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap" rel="stylesheet">
 <link rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css"


### PR DESCRIPTION
## Summary

- **Fix zombie SSH connections**: `exec()` in `ssh.go` could block indefinitely when the TS6 server stopped responding mid-command. The keepalive goroutine would keep sending `version` pings but never get a response, leaving the connection in a zombie state. Added a 15-second read timeout so stale connections are detected and automatically reconnected.
- **Add configurable `max_width`** (fixes #5): New `max_width` config field / `MAX_WIDTH` env var to constrain the viewer layout on wide screens. Accepts any CSS value (e.g. `800px`, `1200px`, `100%`). Defaults to `800px` to preserve existing behavior.

## Changes

| File | What |
|---|---|
| `internal/ts6/ssh.go` | 15s read timeout in `exec()`, `read timeout` added to `isConnectionError()` |
| `internal/config/config.go` | New `MaxWidth` config field |
| `internal/view/vm.go` | `MaxWidth` in view model |
| `http/http-helper.go` | Pass `MaxWidth` from config to view model (default `800px`) |
| `internal/web/templates/ts6viewer.html` | Inline `<style>` override using template value |
| `cmd/server/config.example.json` | Document `max_width` field |
| `entrypoint.sh` | Support `MAX_WIDTH` env var |

## Test plan

- [x] Builds successfully (`go build ./...`)
- [x] Docker image builds and starts correctly
- [x] SSH connection established, viewer data loads
- [x] Keepalive pings work with timeout detection
- [ ] Zombie connection recovery (requires simulating a stale TS6 server)
- [x] `MAX_WIDTH` env var applied in generated config
- [x] Default `800px` matches existing layout