### PR TITLE
fix: reconnect on EOF for channellist / clientlist / serverinfo

### DIFF
--- a/internal/ts6/channel.go
+++ b/internal/ts6/channel.go
@@ -31,7 +31,7 @@ type Channel struct {
 // GetChannelList retrieves all channels using ServerQuery (SSH)
 func GetChannelList(cfg *config.Config, ssh *SSHClient) ([]Channel, error) {
 
-	raw, err := ssh.exec("channellist -topic -flags -limits -voice -icon -secondsempty")
+	raw, err := ssh.Exec("channellist -topic -flags -limits -voice -icon -secondsempty")
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute channellist: %w", err)
 	}

--- a/internal/ts6/client.go
+++ b/internal/ts6/client.go
@@ -45,7 +45,7 @@ func GetClientList(cfg *config.Config, ssh *SSHClient) ([]Client, error) {
 		voiceCmd = "-voice"
 	}
 
-	raw, err := ssh.exec("clientlist -uid -away -groups -times -info -country -icon " + voiceCmd)
+	raw, err := ssh.Exec("clientlist -uid -away -groups -times -info -country -icon " + voiceCmd)
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute clientlist: %w", err)
 	}

--- a/internal/ts6/serverinfo.go
+++ b/internal/ts6/serverinfo.go
@@ -22,7 +22,7 @@ type ServerInfo struct {
 }
 
 func GetServerInfo(cfg *config.Config, c *SSHClient) (*ServerInfo, error) {
-	raw, err := c.exec("serverinfo")
+	raw, err := c.Exec("serverinfo")
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute serverinfo: %w", err)
 	}


### PR DESCRIPTION
## Problem

When the TS6 server closes the persistent query session (idle / server-side drop), every HTTP request in the viewer returns:

```
[SSH] Reusing existing persistent connection
[HTTP] Failed to get channels: failed to execute channellist: EOF
```

The viewer stays in that state until the container is restarted.

Observed in the wild with live TS6 servers; also documented in #4 (symptom-identical, but never actually fixed in code).

## Root cause

`GetChannelList`, `GetClientList`, and `GetServerInfo` call the unexported `ssh.exec(...)` directly. That bypasses `execSafe()` and its reconnect-on-connection-error path — only the exported `Exec()` wraps the command in `execSafe`, and today only the keepalive goroutine goes through `Exec`.

So when `isConnectionError` fires on the HTTP path, there's no retry and no fresh `use sid=N` — the dead-but-open session gets reused forever.

## Fix

Three one-character changes — route all three callers through `Exec()`. `execSafe` already retries once on `isConnectionError`, and `reconnect()` already re-issues `use sid=N` via `newSSHClientWithUse`. The infrastructure is there; it just wasn't being used.

```go
// internal/ts6/channel.go
-raw, err := ssh.exec("channellist …")
+raw, err := ssh.Exec("channellist …")

// internal/ts6/client.go
-raw, err := ssh.exec("clientlist …")
+raw, err := ssh.Exec("clientlist …")

// internal/ts6/serverinfo.go
-raw, err := c.exec("serverinfo")
+raw, err := c.Exec("serverinfo")
```

No behaviour change on the happy path (same command, same parsing). On the error path, a dead session now recovers on the next request instead of needing a container restart.